### PR TITLE
Convert from winrt-rs to windows-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 
 [dependencies]
-winrt = { git = "https://github.com/microsoft/winrt-rs" }
+windows = "0.21.0"
 bindings = { path = "bindings" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # webview2-rs
 
-This is a simple example of using [Rust/WinRT](https://github.com/microsoft/winrt-rs) with WinRT dependencies like [WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) where that component provides its own winmd for describing its API surface as well as a runtime DLL that must be deployed with the app. It is further complicated as WebView2 requires the [VCRTForwarders](https://www.nuget.org/packages/Microsoft.VCRTForwarders.140/) in order to load. This repo provides an example of how this can be achieved.
+This is a simple example of using [the `windows` crate](https://github.com/microsoft/windows-rs) with WinRT dependencies like [WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) where that component provides its own winmd for describing its API surface as well as a runtime DLL that must be deployed with the app. It is further complicated as WebView2 requires the [VCRTForwarders](https://www.nuget.org/packages/Microsoft.VCRTForwarders.140/) in order to load. This repo provides an example of how this can be achieved.
 
-Here I have simply unpacked the respective dependencies and placed them in the well-known `.windows` folder that Rust/WinRT expects.
+Here I have simply unpacked the respective dependencies and placed them in the well-known `.windows` folder that the `windows` crate expects.

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 
 [dependencies]
-winrt = { git = "https://github.com/microsoft/winrt-rs" }
+windows = "0.21.0"
 
 [build-dependencies]
-winrt = { git = "https://github.com/microsoft/winrt-rs" }
+windows = "0.21.0"

--- a/bindings/build.rs
+++ b/bindings/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    winrt::build!(
-        microsoft::web::web_view2::core::*
+    windows::build!(
+        Microsoft::Web::WebView2::Core::*
     );
 }

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -1,1 +1,1 @@
-winrt::include_bindings!();
+windows::include_bindings!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use bindings::*;
-use microsoft::web::web_view2::core::*;
+use Microsoft::Web::WebView2::Core::*;
 
-fn main() -> winrt::Result<()> {
+fn main() -> windows::Result<()> {
     let options = CoreWebView2EnvironmentOptions::new()?;
 
-    options.set_language("croak")?;
+    options.SetLanguage("croak")?;
 
-    println!("{}", options.language()?);
+    println!("{}", options.Language()?);
 
     Ok(())
 }


### PR DESCRIPTION
This PR converts the sample to the current `windows` crate (instead of the deprecated `winrt-rs` repository)